### PR TITLE
chore/build the injected script without hash

### DIFF
--- a/packages/browser-extension/src/content-scripts/content-script.ts
+++ b/packages/browser-extension/src/content-scripts/content-script.ts
@@ -7,7 +7,7 @@ function injectScript(file: string) {
   container.insertBefore(scriptElement, container.children[0]);
   console.log('Emeris Extension loaded');
 }
-const injected = browser.runtime.getURL('/js/inject-emeris.js');
+const injected = browser.runtime.getURL('/inject-emeris.js');
 injectScript(injected);
 
 const sendMessage = async (msg: unknown) => {

--- a/packages/browser-extension/src/manifest.json
+++ b/packages/browser-extension/src/manifest.json
@@ -27,7 +27,7 @@
   "content_scripts": [
     {
       "js": [
-        "js/content-script.js"
+        "content-script.js"
       ],
       "matches": [
         "*://*/*"
@@ -35,7 +35,7 @@
     }
   ],
   "web_accessible_resources": [
-    "/js/inject-emeris.js"
+    "/inject-emeris.js"
   ],
   "browser_action": {
     "browser_style": true,

--- a/packages/browser-extension/vue.config.js
+++ b/packages/browser-extension/vue.config.js
@@ -16,6 +16,9 @@ module.exports = {
   },
   configureWebpack: {
     devtool: "inline-source-map",
+    output: {
+      filename: '[name].js'
+    }
   },
   pluginOptions: {
     browserExtension: {


### PR DESCRIPTION
the injected script is currently build with a hash in the name so it would not be found by the content script. I have no idea when this was introduced.