### PR TITLE
fix: make the raw tx display work again

### DIFF
--- a/packages/browser-extension/src/views/TransactionReview.vue
+++ b/packages/browser-extension/src/views/TransactionReview.vue
@@ -1,32 +1,40 @@
 <template>
   <div class="page" style="padding-bottom: 135px" v-if="pending">
     <h1>Confirm Transaction</h1>
-    <span style="color: #ffffffaa; text-align: center; width: 100%">{{
+    <span class="text-center w-full mb-6" style="color: #ffffffaa">{{
       pending.origin.replace(/http(s)?:\/\//, '')
     }}</span>
     <div style="display: flex; flex-direction: row; margin-bottom: 16px; font-size: 13px; line-height: 24px">
-      <div style="display: flex; flex-direction: row; cursor: pointer">
+      <div v-on:click="this.switchTab" :class="{'secondary-text': this.tab === 'Data'}" style="display: flex; flex-direction: row; cursor: pointer">
         Details
         <div class="badge" style="margin-left: 8px">{{ transaction.messages.length }}</div>
       </div>
-      <span class="secondary-text" style="margin-left: 16px; cursor: pointer">Data</span>
+      <span v-on:click="this.switchTab" :class="{'secondary-text': this.tab === 'Details'}" style="margin-left: 16px; cursor: pointer">Data</span>
     </div>
 
-    <div
-      v-for="(message, index) in transaction.messages"
-      :key="index"
-      style="
-        display: flex;
-        flex-direction: column;
-        padding: 16px;
+    <template v-if="this.tab === 'Details'">
+      <div
+        v-for="(message, index) in transaction.messages"
+        :key="index"
+        style="
+          display: flex;
+          flex-direction: column;
+          padding: 16px;
 
-        background: #171717;
-        border-radius: 8px;
-        margin-bottom: 16px;
-      "
-    >
-      <Message style="flex: 1" :message="message" :chainId="transaction.chainId" />
-    </div>
+          background: #171717;
+          border-radius: 8px;
+          margin-bottom: 16px;
+        "
+      >
+        <Message style="flex: 1" :message="message" :chainId="transaction.chainId" />
+      </div>
+    </template>
+    <template v-else-if="this.tab === 'Data'">
+      <div class="p-4 rounded-xl" style="background: #171717">
+        <h4 class="text-0 mb-3">Custom transaction</h4>
+        <Yaml :json="this.transaction.messages?.length === 1 ? this.transaction.messages[0] : this.transaction.messages" />
+      </div>
+    </template>
 
     <div
       style="
@@ -42,7 +50,8 @@
     >
       <div v-if="error" style="color: #ff6072; margin-top: 16px; text-align: center">{{ error }}</div>
       <div
-        style="display: flex; flex-direction: row; justify-content: space-between; margin-bottom: 8px; font-size: 13px"
+        class="mt-6 mb-2 flex justify-between"
+        style="font-size: 13px"
       >
         <span class="secondary-text">Reference (memo)</span>
         <a
@@ -98,17 +107,30 @@ import Input from '@/components/ui/Input.vue';
 import { GlobalActionTypes } from '@@/store/extension/action-types';
 import { keyHashfromAddress } from '@/utils/basic';
 import { MutationTypes } from '@@/store/extension/mutation-types';
+import Yaml from "@@/components/Yaml.vue";
 
+type TxTab = 'Details' | 'Data';
+interface TxReviewData {
+  tab: TxTab,
+  memo: string;
+  editMemo: boolean;
+  editFees: boolean;
+  fees: {amount: number, denom: string}[];
+  gas: number;
+  error?: string;
+}
 export default defineComponent({
   name: 'Transaction Review',
   components: {
+    Yaml,
     Button,
     Message,
     Slideout,
     Input,
     TotalPrice,
   },
-  data: () => ({
+  data: (): TxReviewData => ({
+    tab: 'Details',
     memo: 'Sent with Emeris',
     editMemo: false,
     editFees: false,
@@ -132,6 +154,9 @@ export default defineComponent({
     },
   },
   methods: {
+    switchTab() {
+      this.tab = this.tab === 'Details' ? 'Data' : 'Details';
+    },
     async cancel() {
       await this.$store.dispatch(GlobalActionTypes.CANCEL_TRANSACTION, this.pending);
       this.$router.push('/');


### PR DESCRIPTION
fixes: #110 
Did some slight style fixes and changed inline styling to tailwind classes here and there where applicable easily.

[How to Test]
Do what it says in this link which doesn't seem to count as a link by github(https://allinbits.slack.com/archives/C02U9SVJT97/p1648442610406659?thread_ts=1648435746.544299&cid=C02U9SVJT97)
with the build that will be appended by the bot.

Click on the 'data' tab and see if it displays the custom tx data